### PR TITLE
fixed settings using wrong scope, leading to broken comment keymapping

### DIFF
--- a/settings/language-solidity.cson
+++ b/settings/language-solidity.cson
@@ -1,4 +1,4 @@
-'.source.sol':
+'.source.solidity':
   'editor':
     'nonWordCharacters': '/\\()"\':,.;<>~!#@%^&*|+=[]{}`?-…'
     'commentStart': '// '


### PR DESCRIPTION
The current package doesn't properly apply the `language-solidity.cson` file to the grammar, which leads to the traditional inline comment keybinding (`ctrl-/` or `cmd-/`) to always add comments as blocks (`/* [code] */`) rather than as inline (`// [code]`). This can be frustrating when commenting larger blocks of code and selectively uncommenting parts as part of debugging etc.

This fix changes the scope defined in `language-solidity.cson` to properly apply what were likely intended settings.